### PR TITLE
Use ESM Supabase client

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -159,7 +159,6 @@
   <div id="toast"></div>
 
   <!-- Scripts: orden requerido -->
-  <script type="module" src="https://unpkg.com/@supabase/supabase-js@2"></script>
   <script type="module" src="/env.js"></script>
   <script type="module" src="/js/main.js"></script>
 </body>

--- a/public/js/supabaseClient.js
+++ b/public/js/supabaseClient.js
@@ -1,6 +1,7 @@
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 import { ENV } from "../env.js";
 
-export const supabase = window.supabase.createClient(
+export const supabase = createClient(
   ENV.SUPABASE_URL,
   ENV.SUPABASE_ANON_KEY
 );


### PR DESCRIPTION
## Summary
- remove the Supabase CDN module script from the HTML shell
- load createClient directly from the esm.sh build in supabaseClient.js and instantiate Supabase without using window

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cc2c4b759c8320b50dda31f6ca678c