### PR TITLE
Fix repeated UI initialisation for equipos and componentes

### DIFF
--- a/public/js/componentes.js
+++ b/public/js/componentes.js
@@ -79,17 +79,26 @@ async function modalConfirmBaja(compId, serie, onDone){
 }
 
 export function initComponentesUI(requestReload){
-  document.querySelector("#co-refrescar").onclick = ()=> requestReload();
+  const btnRefrescar = document.querySelector("#co-refrescar");
+  if (btnRefrescar) btnRefrescar.onclick = () => requestReload?.();
 
-  document.querySelector("#co-tbody").addEventListener("click", async ev=>{
-    const b = ev.target.closest("button[data-act]"); if(!b) return;
-    const id = b.dataset.id, act = b.dataset.act, serie = b.dataset.serie;
-    try{
-      if(act==="co-falla") await modalFallaComponente(id, serie);
-      if(act==="co-baja")  await modalConfirmBaja(id, serie, ()=>requestReload());
-    }catch(err){
-      alert(err.message || err);
-    }
-  });
+  const tbody = document.querySelector("#co-tbody");
+  if (!tbody) return;
+
+  tbody.__coRequestReload = requestReload;
+  if (!tbody.__coListener) {
+    tbody.__coListener = async (ev)=>{
+      const b = ev.target.closest("button[data-act]"); if(!b) return;
+      const id = b.dataset.id, act = b.dataset.act, serie = b.dataset.serie;
+      const reload = tbody.__coRequestReload;
+      try{
+        if(act==="co-falla") await modalFallaComponente(id, serie);
+        if(act==="co-baja")  await modalConfirmBaja(id, serie, ()=>reload?.());
+      }catch(err){
+        alert(err.message || err);
+      }
+    };
+    tbody.addEventListener("click", tbody.__coListener);
+  }
 }
 

--- a/public/js/equipos.js
+++ b/public/js/equipos.js
@@ -358,23 +358,31 @@ export function initEquiposUI(requestReload) {
   const btnCrear = document.querySelector("#eq-crear");
   const btnRef   = document.querySelector("#eq-refrescar");
 
-  if (btnCrear) btnCrear.onclick = () => modalCrearEquipo(() => requestReload());
-  if (btnRef)   btnRef.onclick   = () => requestReload();
+  if (btnCrear) btnCrear.onclick = () => modalCrearEquipo(() => requestReload?.());
+  if (btnRef)   btnRef.onclick   = () => requestReload?.();
 
   // Delegación en la tabla
   const tbody = document.querySelector("#eq-tbody");
-  tbody.addEventListener("click", async (ev) => {
-    const b = ev.target.closest("button[data-act]");
-    if (!b) return;
-    const id  = b.dataset.id;
-    const act = b.dataset.act;
-    try {
-      if (act === "editar")    await modalEditarEquipo(id, () => requestReload());
-      if (act === "ensamblar") await modalEnsamblar(id, () => requestReload());
-      if (act === "quitar")    await modalQuitar(id, () => requestReload());
-      if (act === "falla")     await modalFallaDesdeEquipo(id);
-    } catch (err) {
-      alert(err?.message || err);
-    }
-  });
+  if (!tbody) return;
+
+  tbody.__eqRequestReload = requestReload;
+
+  if (!tbody.__eqListener) {
+    tbody.__eqListener = async (ev) => {
+      const b = ev.target.closest("button[data-act]");
+      if (!b) return;
+      const id  = b.dataset.id;
+      const act = b.dataset.act;
+      const reload = tbody.__eqRequestReload;
+      try {
+        if (act === "editar")    await modalEditarEquipo(id, () => reload?.());
+        if (act === "ensamblar") await modalEnsamblar(id, () => reload?.());
+        if (act === "quitar")    await modalQuitar(id, () => reload?.());
+        if (act === "falla")     await modalFallaDesdeEquipo(id);
+      } catch (err) {
+        alert(err?.message || err);
+      }
+    };
+    tbody.addEventListener("click", tbody.__eqListener);
+  }
 }

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -71,17 +71,13 @@ function initTabs() {
 }
 
 /* ===== Equipos ===== */
-async function loadEquipos() {
+async function loadEquipos({ flash: showFlash = false } = {}) {
   const tbody = $("#eq-tbody");
   if (tbody) tbody.innerHTML = `Cargando…`;
   try {
     const data = await fetchEquipos();
     renderEquipos(data);
-    initEquiposUI(async () => {
-      const refreshed = await fetchEquipos();
-      renderEquipos(refreshed);
-      flash("Actualizado");
-    });
+    if (showFlash) flash("Actualizado");
   } catch (e) {
     console.error(e);
     if (tbody) tbody.innerHTML = `Error al cargar`;
@@ -90,17 +86,13 @@ async function loadEquipos() {
 }
 
 /* ===== Componentes ===== */
-async function loadComponentes() {
+async function loadComponentes({ flash: showFlash = false } = {}) {
   const tbody = $("#co-tbody");
   if (tbody) tbody.innerHTML = `Cargando…`;
   try {
     const data = await fetchComponentes();
     renderComponentes(data);
-    initComponentesUI(async () => {
-      const refreshed = await fetchComponentes();
-      renderComponentes(refreshed);
-      flash("Actualizado");
-    });
+    if (showFlash) flash("Actualizado");
   } catch (e) {
     console.error(e);
     if (tbody) tbody.innerHTML = `Error al cargar`;
@@ -122,12 +114,14 @@ async function init() {
   await initHeader();
   initTabs();
 
+  const requestEquiposReload = () => loadEquipos({ flash: true });
+  const requestComponentesReload = () => loadComponentes({ flash: true });
+
+  initEquiposUI(requestEquiposReload);
+  initComponentesUI(requestComponentesReload);
+
   // Tab por defecto
   await loadEquipos();
-
-  // Toolbar
-  $("#eq-refrescar")?.addEventListener("click", () => loadEquipos());
-  $("#co-refrescar")?.addEventListener("click", () => loadComponentes());
 }
 
 // Evitar doble init si el bundle carga dos veces por error


### PR DESCRIPTION
## Summary
- initialize equipos and componentes UI handlers only once from main bootstrap
- store reload callbacks so refresh operations reuse the same function with optional flash
- guard equipos/componentes table listeners to avoid multiple registrations

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68cc444bb18c83208c192b183c8af546