### PR TITLE
K3 autofix: parametrize DB image for DB CI

### DIFF
--- a/.github/workflows/db-ci.yml
+++ b/.github/workflows/db-ci.yml
@@ -1,26 +1,34 @@
 name: DB — Migrations & Smoke
+
 on:
   pull_request:
   push:
     branches: [ main ]
+
+env:
+  DB_IMAGE: ${{ vars.DB_IMAGE != '' && vars.DB_IMAGE || 'postgres:15' }}
 
 jobs:
   db-check:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: supabase/postgres:15.1.0
+        image: ${{ env.DB_IMAGE }}
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: appdb
-        ports: ["5432:5432"]
+        ports:
+          - "5432:5432"
         options: >-
           --health-cmd="pg_isready -U postgres"
           --health-interval=5s --health-timeout=5s --health-retries=20
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Show DB image
+        run: echo "Using DB image: ${DB_IMAGE:-postgres:15}"
 
       - name: Wait for DB
         run: |


### PR DESCRIPTION
## Summary
- parameterize the workflow database image with a default of postgres:15 and log which image is used while keeping migration listing
- document the root cause and remediation steps for the failing DB CI job

## Testing
- not run (CI-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68ceeded53fc8320bb310d78d207edc6