### PR TITLE
Add manual trigger to DB CI workflow

### DIFF
--- a/.github/workflows/db-ci.yml
+++ b/.github/workflows/db-ci.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
   push:
     branches: [ main ]
+  workflow_dispatch: {}
 
 env:
   DB_IMAGE: ${{ vars.DB_IMAGE != '' && vars.DB_IMAGE || 'postgres:15' }}


### PR DESCRIPTION
## Summary
- add a workflow_dispatch trigger to the DB migrations and smoke workflow so it can run manually

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cef843f554832089406086df56a1f1